### PR TITLE
OpenGL Legacy Support Development Is Finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ Features
 To Do
 -----
 - ???
+
+Known Issues
+------------
+- Intel HD Graphics 4000 may not initialize OpenGL correctly

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Paunch is a 2D game engine written in Go.
 
 Development Status
 ------------------
-Paunch is still heavily in development, and lacks the key features and proper
-testing that characterizes a solid game engine. Please check back frequently,
-as work is being done on Paunch almost every day.
+Paunch is nearing a stable release. There may still be minor API changes, but
+hopefully future changes will either be bug fixes or new features.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Paunch requires a few C libraries to be installed before use.
 Paunch needs the GLFW3 library installed to build correctly, which you can find
 on their website [here](www.glfw.org). Make sure you build GLFW3 as a _shared
 library_. When using cmake, you have to include the `-DBUILD_SHARED_LIBS=on`
-flag.
+flag. You may also want to include the `-GLFW_USE_OPTIMUS_HPG=on` flag if you
+are on a system with Nvidia Optimus in order to force Optimus to use the
+dedicated graphics card. Intel integrated graphics sometimes have trouble
+initializing legacy OpenGL functions.
 
 Paunch also requires the OpenAL library to be installed. You can find a
 download [here](http://kcat.strangesoft.net/openal.html).

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Once you have the dependencies installed, just run go get!
 
 Notes
 -----
-As of right now, Paunch requires that your graphics card supports OpenGL 3.2 or
-higher. This is a limitation I hope to get rid of as soon as possible.
+Your graphics card must support at least OpenGL 2.1 or you will get an error
+complaining that OpenGL could not be initialized.
 
 Features
 --------
@@ -44,9 +44,8 @@ Features
 - Easy event management through object polling
 - Easy menu management
 - Music and sound effect support
-- More to come!
+- Flexible OpenGL version support
 
 To Do
 -----
-- Support for pre-3.0 OpenGL versions
-- Probably more...
+- ???

--- a/constants.go
+++ b/constants.go
@@ -229,3 +229,13 @@ const (
 	ShapeTriangleFan   = Shape(gl.TRIANGLE_FAN)
 	ShapePolygon       = Shape(gl.POLYGON)
 )
+
+type Version int
+
+// OpenGL Version Management
+const (
+	_ Version = iota
+	VersionNew
+	VersionOld
+	VersionAutomatic
+)

--- a/constants.go
+++ b/constants.go
@@ -1,8 +1,8 @@
 package paunch
 
 import (
-	gl "github.com/chsc/gogl/gl32"
 	glfw "github.com/go-gl/glfw3"
+	"github.com/velovix/gl"
 	al "github.com/vova616/go-openal/openal"
 )
 

--- a/draw.go
+++ b/draw.go
@@ -48,16 +48,14 @@ func initDraw(version Version) error {
 		return errors.New("initializing OpenGL 2.0")
 	} else if err = gl.InitVersion21(); err != nil {
 		return errors.New("initializing OpenGL 2.1")
-	} else if err = gl.InitLegacy(); err != nil {
-		return errors.New("initializing OpenGL legacy functions")
 	}
 
 	paunchGLVersion = VersionOld
 
 	if version == VersionNew || version == VersionAutomatic {
-		if err := gl.InitVersion32(); err != nil {
+		if err := gl.InitVersion30(); err != nil {
 			if version == VersionNew {
-				return errors.New("initializing OpenGL 3.2")
+				return errors.New("initializing OpenGL 3.0")
 			}
 		} else {
 			paunchGLVersion = VersionNew

--- a/draw.go
+++ b/draw.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 )
 
+var paunchGLVersion Version
+
 func checkForErrors() error {
 
 	err := OpenGLError{make([]gl.Enum, 0)}
@@ -26,12 +28,38 @@ func checkForErrors() error {
 	return err
 }
 
-func initDraw() error {
+func initDraw(version Version) error {
 
 	runtime.LockOSThread()
 
-	if err := gl.Init(); err != nil {
-		return errors.New("initializing OpenGL")
+	if err := gl.InitVersion10(); err != nil {
+		return errors.New("initializing OpenGL 1.0")
+	} else if err = gl.InitVersion11(); err != nil {
+		return errors.New("initializing OpenGL 1.1")
+	} else if err = gl.InitVersion12(); err != nil {
+		return errors.New("initializing OpenGL 1.2")
+	} else if err = gl.InitVersion13(); err != nil {
+		return errors.New("initializing OpenGL 1.3")
+	} else if err = gl.InitVersion14(); err != nil {
+		return errors.New("initializing OpenGL 1.4")
+	} else if err = gl.InitVersion15(); err != nil {
+		return errors.New("initializing OpenGL 1.5")
+	} else if err = gl.InitVersion20(); err != nil {
+		return errors.New("initializing OpenGL 2.0")
+	} else if err = gl.InitVersion21(); err != nil {
+		return errors.New("initializing OpenGL 2.1")
+	}
+
+	paunchGLVersion = VersionOld
+
+	if version == VersionNew || version == VersionAutomatic {
+		if err := gl.InitVersion32(); err != nil {
+			if version == VersionNew {
+				return errors.New("initializing OpenGL 3.2")
+			}
+		} else {
+			paunchGLVersion = VersionNew
+		}
 	}
 
 	gl.ClearColor(0.0, 0.0, 0.0, 1.0)

--- a/draw.go
+++ b/draw.go
@@ -7,6 +7,7 @@ import (
 )
 
 var paunchGLVersion Version
+var paunchEffect *Effect
 
 func checkForErrors() error {
 
@@ -94,6 +95,8 @@ func UseEffect(effect *Effect) error {
 
 	effect.uniforms = make(map[string]gl.Int)
 
+	paunchEffect = effect
+
 	return checkForErrors()
 }
 
@@ -101,4 +104,5 @@ func UseEffect(effect *Effect) error {
 func DisableEffects() {
 
 	gl.UseProgram(0)
+	paunchEffect = nil
 }

--- a/draw.go
+++ b/draw.go
@@ -2,7 +2,7 @@ package paunch
 
 import (
 	"errors"
-	gl "github.com/chsc/gogl/gl32"
+	"github.com/velovix/gl"
 	"runtime"
 )
 
@@ -48,6 +48,8 @@ func initDraw(version Version) error {
 		return errors.New("initializing OpenGL 2.0")
 	} else if err = gl.InitVersion21(); err != nil {
 		return errors.New("initializing OpenGL 2.1")
+	} else if err = gl.InitLegacy(); err != nil {
+		return errors.New("initializing OpenGL legacy functions")
 	}
 
 	paunchGLVersion = VersionOld

--- a/effect.go
+++ b/effect.go
@@ -3,7 +3,7 @@ package paunch
 import (
 	"errors"
 	"fmt"
-	gl "github.com/chsc/gogl/gl32"
+	"github.com/velovix/gl"
 	"io/ioutil"
 	"strings"
 )

--- a/effect.go
+++ b/effect.go
@@ -96,7 +96,8 @@ func (effect *Effect) SetVariable4i(variable string, val1 int, val2 int, val3 in
 }
 
 // SetVariableui sets a specified variable to the supplied integer to be passed
-// into an effect.
+// into an effect. This functionality is not avaliable if Paunch is initialized
+// with VersionOld.
 func (effect *Effect) SetVariableui(variable string, val uint) error {
 
 	if paunchGLVersion == VersionOld {
@@ -116,7 +117,8 @@ func (effect *Effect) SetVariableui(variable string, val uint) error {
 }
 
 // SetVariable2ui sets a specified variable to the two supplied integers to be
-// passed into an effect.
+// passed into an effect. This functionality is not avaliable if Paunch is
+// initialized with VersionOld.
 func (effect *Effect) SetVariable2ui(variable string, val1 uint, val2 uint) error {
 
 	if paunchGLVersion == VersionOld {
@@ -136,7 +138,8 @@ func (effect *Effect) SetVariable2ui(variable string, val1 uint, val2 uint) erro
 }
 
 // SetVariable3ui sets a specified variable to the three supplied integers to
-// be passed into an effect.
+// be passed into an effect. This functionality is not avaliable if Paunch is
+// initialized with VersionOld.
 func (effect *Effect) SetVariable3ui(variable string, val1 uint, val2 uint, val3 uint) error {
 
 	if paunchGLVersion == VersionOld {
@@ -156,7 +159,8 @@ func (effect *Effect) SetVariable3ui(variable string, val1 uint, val2 uint, val3
 }
 
 // SetVariable4ui sets a specified variable to the four supplied integers to
-// be passed into an effect.
+// be passed into an effect. This functionality is not avaliable if Paunch is
+// initialized with VersionOld.
 func (effect *Effect) SetVariable4ui(variable string, val1 uint, val2 uint, val3 uint, val4 uint) error {
 
 	if paunchGLVersion == VersionOld {

--- a/effect.go
+++ b/effect.go
@@ -99,6 +99,10 @@ func (effect *Effect) SetVariable4i(variable string, val1 int, val2 int, val3 in
 // into an effect.
 func (effect *Effect) SetVariableui(variable string, val uint) error {
 
+	if paunchGLVersion == VersionOld {
+		return errors.New("cannot use SetVariableui with the current OpenGL version")
+	}
+
 	var currEffect gl.Int
 	gl.GetIntegerv(gl.CURRENT_PROGRAM, &currEffect)
 	if gl.Uint(currEffect) != effect.program {
@@ -114,6 +118,10 @@ func (effect *Effect) SetVariableui(variable string, val uint) error {
 // SetVariable2ui sets a specified variable to the two supplied integers to be
 // passed into an effect.
 func (effect *Effect) SetVariable2ui(variable string, val1 uint, val2 uint) error {
+
+	if paunchGLVersion == VersionOld {
+		return errors.New("cannot use SetVariable2ui with the current OpenGL version")
+	}
 
 	var currEffect gl.Int
 	gl.GetIntegerv(gl.CURRENT_PROGRAM, &currEffect)
@@ -131,6 +139,10 @@ func (effect *Effect) SetVariable2ui(variable string, val1 uint, val2 uint) erro
 // be passed into an effect.
 func (effect *Effect) SetVariable3ui(variable string, val1 uint, val2 uint, val3 uint) error {
 
+	if paunchGLVersion == VersionOld {
+		return errors.New("cannot use SetVariable3ui with the current OpenGL version")
+	}
+
 	var currEffect gl.Int
 	gl.GetIntegerv(gl.CURRENT_PROGRAM, &currEffect)
 	if gl.Uint(currEffect) != effect.program {
@@ -146,6 +158,10 @@ func (effect *Effect) SetVariable3ui(variable string, val1 uint, val2 uint, val3
 // SetVariable4ui sets a specified variable to the four supplied integers to
 // be passed into an effect.
 func (effect *Effect) SetVariable4ui(variable string, val1 uint, val2 uint, val3 uint, val4 uint) error {
+
+	if paunchGLVersion == VersionOld {
+		return errors.New("cannot use SetVariable4ui with the current OpenGL version")
+	}
 
 	var currEffect gl.Int
 	gl.GetIntegerv(gl.CURRENT_PROGRAM, &currEffect)

--- a/errors.go
+++ b/errors.go
@@ -2,7 +2,7 @@ package paunch
 
 import (
 	"fmt"
-	gl "github.com/chsc/gogl/gl32"
+	"github.com/velovix/gl"
 )
 
 // LineGetPointFromErrorType are the types of errors a LineGetPointFromError

--- a/examples/draw-image.go
+++ b/examples/draw-image.go
@@ -18,7 +18,7 @@ func main() {
 	paunch.SetWindowSize(640, 480)
 	paunch.SetWindowTitle("Test Window")
 
-	err := paunch.Start()
+	_, err := paunch.Start(paunch.VersionAutomatic)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/event-manager.go
+++ b/examples/event-manager.go
@@ -60,7 +60,7 @@ func main() {
 	paunch.SetWindowSize(640, 480)
 	paunch.SetWindowTitle("Use the arrow keys to move the object!")
 
-	err := paunch.Start()
+	_, err := paunch.Start(paunch.VersionAutomatic)
 	if err != nil {
 		panic(err)
 	}
@@ -75,8 +75,8 @@ func main() {
 	player := NewPlayer(288, 208)
 
 	eventManager = paunch.NewEventManager()
-	eventManager.SetObjects([]interface{}{&player}) // Add the Player object to the EventManager's object list.
-	eventManager.GetUserEvents(true)                // Set the EventManager to automatically respond to user events.
+	eventManager.Objects = []interface{}{&player} // Add the Player object to the EventManager's object list.
+	eventManager.GetUserEvents(true)              // Set the EventManager to automatically respond to user events.
 
 	lastFrame := time.Now()
 

--- a/examples/shader/main.frag
+++ b/examples/shader/main.frag
@@ -1,19 +1,16 @@
-#version 320
+#version 120
 
 // Input
-smooth in vec2 f_texcoord;
+varying vec2 f_texcoord;
 uniform sampler2D tex_id;
 uniform int shape_mode;
 uniform vec4 shape_color;
 
-// Outputs
-out vec4 fragColor;
-
 void main() {
 
 	if(shape_mode == 0) {
-		fragColor = texture2D(tex_id, f_texcoord);
+		gl_FragColor = texture2D(tex_id, gl_TexCoord[0].st);
 	} else {
-		fragColor = shape_color;
+		gl_FragColor = shape_color;
 	}
 }

--- a/examples/shader/main.vert
+++ b/examples/shader/main.vert
@@ -1,11 +1,11 @@
-#version 320
+#version 120
 
 // Inputs
-layout(location = 0) in vec4 position;
-layout(location = 1) in vec2 texcoord;
+attribute vec4 position;
+attribute vec2 texcoord;
 
 // Outputs
-smooth out vec2 f_texcoord;
+varying vec2 f_texcoord;
 
 uniform vec2 screen_size;
 
@@ -26,6 +26,7 @@ void main() {
 
 	vertex = adjustScreenPixels(vertex);
 
+	gl_TexCoord[0].st = texcoord;
 	f_texcoord = texcoord;
 	gl_Position = vertex;
 }

--- a/examples/window.go
+++ b/examples/window.go
@@ -15,7 +15,7 @@ func main() {
 	paunch.SetWindowTitle("Test Window")
 
 	// Starts Paunch, initializing things and opening the window
-	err := paunch.Start()
+	_, err := paunch.Start(paunch.VersionAutomatic)
 	if err != nil {
 		panic(err)
 	}

--- a/paunch.go
+++ b/paunch.go
@@ -30,7 +30,7 @@ func Start(version Version) (Version, error) {
 		return VersionOld, err
 	}
 
-	version, err := initDraw(version)
+	err = initDraw(version)
 	if err != nil {
 		return VersionOld, err
 	}

--- a/paunch.go
+++ b/paunch.go
@@ -11,7 +11,7 @@ func init() {
 // Start starts the Paunch system by opening the window and beginning to
 // recieve input. Some Paunch operations may fail if this function has not yet
 // been called, including all drawing commands.
-func Start() error {
+func Start(version Version) error {
 
 	var err error
 
@@ -24,7 +24,7 @@ func Start() error {
 		return err
 	}
 
-	err = initDraw()
+	err = initDraw(version)
 	if err != nil {
 		return err
 	}

--- a/paunch.go
+++ b/paunch.go
@@ -10,31 +10,37 @@ func init() {
 
 // Start starts the Paunch system by opening the window and beginning to
 // recieve input. Some Paunch operations may fail if this function has not yet
-// been called, including all drawing commands.
-func Start(version Version) error {
+// been called, including all drawing commands. The version variable sets how
+// Paunch initializes OpenGL. VersionOld initializes OpenGL 2.1. A few
+// Paunch functionalities are not avaliable in this version. VersionNew
+// initializes OpenGL 3.0, where all functionalities are avaliable.
+// VersionAutomatic initializes the highest OpenGL version that the graphics
+// chip will support. Start returns the resulting version and an error, if any.
+// The returned version may not be accurate if Start results in an error.
+func Start(version Version) (Version, error) {
 
 	var err error
 
 	err = initWindows()
 	if err != nil {
-		return err
+		return VersionOld, err
 	}
 	err = paunchWindow.open()
 	if err != nil {
-		return err
+		return VersionOld, err
 	}
 
-	err = initDraw(version)
+	version, err := initDraw(version)
 	if err != nil {
-		return err
+		return VersionOld, err
 	}
 
 	err = startAudio()
 	if err != nil {
-		return err
+		return paunchGLVersion, err
 	}
 
-	return nil
+	return paunchGLVersion, nil
 }
 
 // Stop safely closes the Paunch instance.

--- a/renderable.go
+++ b/renderable.go
@@ -1,7 +1,7 @@
 package paunch
 
 import (
-	gl "github.com/chsc/gogl/gl32"
+	"github.com/velovix/gl"
 	"image"
 	"image/png"
 	"os"

--- a/renderable.go
+++ b/renderable.go
@@ -193,6 +193,7 @@ func (renderable *Renderable) Draw(frame int) error {
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, renderable.vertexBuffer)
 	gl.VertexAttribPointer(gl.Uint(0), 2, gl.FLOAT, gl.FALSE, 0, gl.Offset(nil, 0))
+	gl.BindAttribLocation(paunchEffect.program, gl.Uint(0), gl.GLString("position"))
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
 	if renderable.texcoordBuffer != 0 {
@@ -200,6 +201,7 @@ func (renderable *Renderable) Draw(frame int) error {
 
 		gl.BindBuffer(gl.ARRAY_BUFFER, renderable.texcoordBuffer)
 		gl.VertexAttribPointer(gl.Uint(1), 2, gl.FLOAT, gl.FALSE, 0, gl.Offset(nil, 0))
+		gl.BindAttribLocation(paunchEffect.program, gl.Uint(0), gl.GLString("texcoord"))
 		gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
 		gl.BindTexture(gl.TEXTURE_2D, renderable.texture[frame])

--- a/window.go
+++ b/window.go
@@ -2,8 +2,8 @@ package paunch
 
 import (
 	"errors"
-	gl "github.com/chsc/gogl/gl32"
 	glfw "github.com/go-gl/glfw3"
+	"github.com/velovix/gl"
 )
 
 type _Window struct {


### PR DESCRIPTION
Paunch no longer relies on OpenGL 3+ to function. I don't plan on adding legacy support for any version lower than 2.1, considering that covers ten years.
